### PR TITLE
fix: sidebar active link text visibility

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,9 @@ export default defineConfig({
     starlight({
       title: 'Claude Code Mastery',
       description: 'The most comprehensive course on mastering Claude Code — from foundation to production. By ShipWithAI.',
+      customCss: [
+        './src/styles/custom.css',
+      ],
       defaultLocale: 'en',
       locales: {
         en: { label: 'English', lang: 'en' },

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,0 +1,5 @@
+[aria-current="page"] {
+  color: #ffffff !important;
+  background-color: rgba(129, 140, 248, 0.2) !important;
+  font-weight: 600;
+}


### PR DESCRIPTION
Active sidebar links had background color hiding text due to Starlight's default accent color conflicting with text-invert. Added custom CSS to force white text on indigo-tinted background.

## What does this PR do?
<!-- Brief description -->

## Related issue
<!-- Link to issue if applicable -->

## Checklist
- [ ] Content follows 7-block structure
- [ ] No spelling/grammar errors
- [ ] Vietnamese version updated (if applicable)
- [ ] Tested locally with `npm run dev`
