### PR TITLE
fix: theme/language select dropdown unreadable in dark mode

### DIFF
--- a/src/styles/starlight-overrides.css
+++ b/src/styles/starlight-overrides.css
@@ -238,6 +238,17 @@ header {
   background-color: rgba(248, 250, 252, 0.85);
 }
 
+/* ── Header controls: theme & language selectors ── */
+/* Starlight's Select.astro reads --sl-color-bg-nav for <option> bg.
+   Our gray-6 override makes it near-transparent, so dropdown options
+   render as white-on-white. Fix by pointing it to a solid surface. */
+:root {
+  --sl-color-bg-nav: var(--color-bg-base);
+}
+[data-theme="light"] {
+  --sl-color-bg-nav: var(--color-bg-base);
+}
+
 /* ============================================================
    Sidebar improvements
    ============================================================ */


### PR DESCRIPTION
 **Root cause:** Our custom CSS overrides `--sl-color-gray-6` to a near-transparent color, but Starlight uses that variable for dropdown backgrounds (`--sl-color-bg-nav`).

  **Fix:** Set `--sl-color-bg-nav` to a solid background color for both dark and light themes.

  ## What does this PR do?
  Makes the Dark/Light/Auto and English/Tiếng Việt dropdown options readable in both themes.

  ## Checklist
  - [x] Tested locally with `npm run dev`
  - [ ] ~Content follows 7-block structure~ (CSS-only, no content changes)
  - [ ] ~Vietnamese version updated~ (not applicable)