### PR TITLE
feat: adaptive per-diagram rendering for mermaid

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,8 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import sitemap from '@astrojs/sitemap';
 import { visit } from 'unist-util-visit';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 /** Lightweight rehype plugin: converts ```mermaid code blocks to <figure class="mermaid-diagram"> for client-side rendering. */
 const VALID_MODES = ['fit', 'scroll', 'modal'];
@@ -68,6 +70,11 @@ function rehypeMermaidPre() {
   };
 }
 
+const mermaidClientScript = readFileSync(
+  fileURLToPath(new URL('./src/scripts/mermaid-client.js', import.meta.url)),
+  'utf-8'
+);
+
 export default defineConfig({
   site: 'https://course.shipwithai.io',
   markdown: {
@@ -81,7 +88,7 @@ export default defineConfig({
         {
           tag: 'script',
           attrs: { type: 'module' },
-          content: `import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';mermaid.initialize({startOnLoad:true,theme:'dark'});`,
+          content: mermaidClientScript,
         },
         {
           tag: 'script',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,7 +4,9 @@ import starlight from '@astrojs/starlight';
 import sitemap from '@astrojs/sitemap';
 import { visit } from 'unist-util-visit';
 
-/** Lightweight rehype plugin: converts ```mermaid code blocks to <pre class="mermaid"> for client-side rendering. */
+/** Lightweight rehype plugin: converts ```mermaid code blocks to <figure class="mermaid-diagram"> for client-side rendering. */
+const VALID_MODES = ['fit', 'scroll', 'modal'];
+
 function rehypeMermaidPre() {
   return (tree) => {
     visit(tree, 'element', (node, index, parent) => {
@@ -15,12 +17,51 @@ function rehypeMermaidPre() {
         node.children[0].properties?.className?.includes('language-mermaid')
       ) {
         const code = node.children[0];
-        const text = code.children?.find((c) => c.type === 'text')?.value || '';
+        let text = code.children?.find((c) => c.type === 'text')?.value || '';
+
+        // Parse manual override directive: %% mode:fit|scroll|modal %%
+        const directiveRe = /^\s*%%\s*mode:([a-z]+)\s*%%\s*$/m;
+        const match = text.match(directiveRe);
+        let mode = null;
+        if (match) {
+          mode = match[1];
+          if (!VALID_MODES.includes(mode)) {
+            throw new Error(
+              `[rehypeMermaidPre] Invalid mode "${mode}" in mermaid directive. ` +
+              `Valid values: ${VALID_MODES.join(', ')}.`
+            );
+          }
+          text = text.replace(directiveRe, '').replace(/^\n+/, '');
+        }
+
+        const sourceLines = Math.max(3, text.split('\n').length);
+
+        const figureProps = {
+          className: ['mermaid-diagram'],
+          role: 'img',
+          'aria-label': 'Diagram',
+          style: `--source-lines: ${sourceLines}`,
+        };
+        if (mode) figureProps['data-mode'] = mode;
+
         parent.children[index] = {
           type: 'element',
-          tagName: 'pre',
-          properties: { className: ['mermaid'] },
-          children: [{ type: 'text', value: text }],
+          tagName: 'figure',
+          properties: figureProps,
+          children: [
+            {
+              type: 'element',
+              tagName: 'pre',
+              properties: { className: ['mermaid'] },
+              children: [{ type: 'text', value: text }],
+            },
+            {
+              type: 'element',
+              tagName: 'figcaption',
+              properties: { className: ['sr-only'] },
+              children: [{ type: 'text', value: text }],
+            },
+          ],
         };
       }
     });

--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -4,7 +4,32 @@
 
 import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
 
-mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+mermaid.initialize({
+  startOnLoad: false,
+  theme: 'default',
+  themeVariables: {
+    fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+    fontSize: '14px',
+    primaryColor: '#e0e7ff',
+    primaryTextColor: '#1f2937',
+    primaryBorderColor: '#6366f1',
+    lineColor: '#4b5563',
+    secondaryColor: '#fef3c7',
+    tertiaryColor: '#fee2e2',
+  },
+});
+
+// Mermaid v11 sets width="100%" + inline max-width on every SVG, which conflicts
+// with our strategy-level CSS sizing (collapses .fits to 0x0, compresses .scrolls,
+// bloats .modal). Replace with explicit viewBox-derived pixel attrs so our CSS
+// can cleanly control final size.
+function fixSvgDimensions(svg) {
+  const vb = svg.viewBox?.baseVal;
+  if (!vb || !vb.width || !vb.height) return;
+  svg.setAttribute('width', Math.ceil(vb.width));
+  svg.setAttribute('height', Math.ceil(vb.height));
+  svg.style.maxWidth = '';
+}
 
 // Classifier thresholds (tunable).
 const FITS_RATIO_MAX    = 1.05;  // within 5% of container width = fits
@@ -42,10 +67,10 @@ function classify(figure) {
   const r = W_svg / W_box;
 
   let mode;
-  if      (r <= FITS_RATIO_MAX)                 mode = 'fits';
-  else if (H_svg > W_box * TALL_HEIGHT_RATIO)   mode = 'modal';
-  else if (r <= SCROLL_RATIO_MAX)               mode = 'scrolls';
-  else                                          mode = 'modal';
+  if      (H_svg > W_box * TALL_HEIGHT_RATIO)   mode = 'modal';    // tall → modal (any width)
+  else if (r <= FITS_RATIO_MAX)                 mode = 'fits';     // short AND ≈container → fit
+  else if (r <= SCROLL_RATIO_MAX)               mode = 'scrolls';  // short AND ≤2.5× → scroll
+  else                                          mode = 'modal';    // very wide → modal
 
   figure.classList.remove('fits', 'scrolls', 'modal');
   figure.classList.add(mode);
@@ -122,10 +147,14 @@ function openModalFor(figure) {
   if (!svg) return;
 
   const clone = svg.cloneNode(true);
-  clone.removeAttribute('id');  // avoid duplicate IDs in DOM
+  // Keep the root id — mermaid emits a <style> block inside the SVG that is
+  // scoped by #<id>, so stripping it would drop all node/edge styling in the
+  // clone (black shapes, default colours). The duplicate id is only present
+  // while the dialog is open and scoped to two visual contexts.
   body.innerHTML = '';
   body.appendChild(clone);
   body.style.setProperty('--zoom', '1');
+  body.scrollTo({ left: 0, top: 0 });
 
   // Copy aria-label from the source figure for screen readers
   const label = figure.getAttribute('aria-label');
@@ -154,14 +183,18 @@ document.body.addEventListener('keydown', (e) => {
   }
 });
 
-// Render every mermaid <pre> inside a figure and classify each figure.
+// Render every mermaid <pre> inside a figure, normalise SVG sizing, classify.
 async function renderAndClassify() {
   try {
     await mermaid.run({ querySelector: '.mermaid-diagram pre.mermaid' });
   } catch (err) {
     console.error('[mermaid] render failed:', err);
   }
-  document.querySelectorAll('.mermaid-diagram').forEach(classify);
+  document.querySelectorAll('.mermaid-diagram').forEach((fig) => {
+    const svg = fig.querySelector('svg');
+    if (svg) fixSvgDimensions(svg);
+    classify(fig);
+  });
 }
 
 // Fire on SPA nav (if view transitions are enabled) AND on initial load.

--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -32,9 +32,13 @@ function fixSvgDimensions(svg) {
 }
 
 // Classifier thresholds (tunable).
+// Rationale: diagrams where >~30% of content is off-screen on first render
+// feel broken — users don't reliably discover the scrollbar. Prefer
+// modal-thumbnail (whole diagram visible at a glance, click to zoom) over
+// horizontal scroll unless the overflow is small.
 const FITS_RATIO_MAX    = 1.05;  // within 5% of container width = fits
-const SCROLL_RATIO_MAX  = 2.5;   // up to 2.5x wider = horizontal scroll
-const TALL_HEIGHT_RATIO = 1.5;   // H/W_box > 1.5 = modal
+const SCROLL_RATIO_MAX  = 1.2;   // up to 1.2x wider = horizontal scroll (near-fit)
+const TALL_HEIGHT_RATIO = 1.0;   // H/W_box > 1.0 = modal
 
 function syncTabindex(figure) {
   if (figure.classList.contains('modal')) {

--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -6,14 +6,50 @@ import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.mi
 
 mermaid.initialize({ startOnLoad: false, theme: 'dark' });
 
-// Render every mermaid <pre> inside a figure and (later) classify each figure.
+// Classifier thresholds (tunable).
+const FITS_RATIO_MAX    = 1.05;  // within 5% of container width = fits
+const SCROLL_RATIO_MAX  = 2.5;   // up to 2.5x wider = horizontal scroll
+const TALL_HEIGHT_RATIO = 1.5;   // H/W_box > 1.5 = modal
+
+function classify(figure) {
+  // Manual override wins.
+  if (figure.dataset.mode) {
+    figure.classList.remove('fits', 'scrolls', 'modal');
+    // dataset values are 'fit' | 'scroll' | 'modal'; class form is 'fits' | 'scrolls' | 'modal'.
+    const classForMode = { fit: 'fits', scroll: 'scrolls', modal: 'modal' }[figure.dataset.mode];
+    if (classForMode) figure.classList.add(classForMode);
+    return;
+  }
+
+  const svg = figure.querySelector('svg');
+  if (!svg || !svg.viewBox?.baseVal) return;  // pre-render or error state
+
+  const vb = svg.viewBox.baseVal;
+  const W_svg = vb.width;
+  const H_svg = vb.height;
+  const W_box = figure.clientWidth;
+  if (W_box === 0) return;  // not yet laid out
+
+  const r = W_svg / W_box;
+
+  let mode;
+  if      (r <= FITS_RATIO_MAX)                 mode = 'fits';
+  else if (H_svg > W_box * TALL_HEIGHT_RATIO)   mode = 'modal';
+  else if (r <= SCROLL_RATIO_MAX)               mode = 'scrolls';
+  else                                          mode = 'modal';
+
+  figure.classList.remove('fits', 'scrolls', 'modal');
+  figure.classList.add(mode);
+}
+
+// Render every mermaid <pre> inside a figure and classify each figure.
 async function renderAndClassify() {
   try {
     await mermaid.run({ querySelector: '.mermaid-diagram pre.mermaid' });
   } catch (err) {
     console.error('[mermaid] render failed:', err);
   }
-  // classifier + modal wiring added in later tasks
+  document.querySelectorAll('.mermaid-diagram').forEach(classify);
 }
 
 // Fire on SPA nav (if view transitions are enabled) AND on initial load.
@@ -25,3 +61,11 @@ if (document.readyState === 'loading') {
 } else {
   renderAndClassify();
 }
+
+let resizeTimer;
+window.addEventListener('resize', () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    document.querySelectorAll('.mermaid-diagram').forEach(classify);
+  }, 200);
+});

--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -87,6 +87,31 @@ function ensureModal() {
     body.style.setProperty('--zoom', '1');
   });
 
+  // Zoom controls (+ / − / Reset)
+  const ZOOM_MIN = 0.5;
+  const ZOOM_MAX = 3;
+  const ZOOM_STEP = 0.25;
+
+  function getZoom() {
+    return parseFloat(body.style.getPropertyValue('--zoom')) || 1;
+  }
+  function setZoom(z) {
+    const clamped = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
+    body.style.setProperty('--zoom', String(clamped));
+  }
+
+  dialog.querySelector('.mermaid-modal__zoom').addEventListener('click', (e) => {
+    const btn = e.target.closest('button[data-zoom]');
+    if (!btn) return;
+    const action = btn.dataset.zoom;
+    if (action === '+') setZoom(getZoom() + ZOOM_STEP);
+    else if (action === '-') setZoom(getZoom() - ZOOM_STEP);
+    else if (action === '0') {
+      setZoom(1);
+      body.scrollTo({ left: 0, top: 0 });
+    }
+  });
+
   return dialog;
 }
 

--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -11,6 +11,14 @@ const FITS_RATIO_MAX    = 1.05;  // within 5% of container width = fits
 const SCROLL_RATIO_MAX  = 2.5;   // up to 2.5x wider = horizontal scroll
 const TALL_HEIGHT_RATIO = 1.5;   // H/W_box > 1.5 = modal
 
+function syncTabindex(figure) {
+  if (figure.classList.contains('modal')) {
+    figure.setAttribute('tabindex', '0');
+  } else {
+    figure.removeAttribute('tabindex');
+  }
+}
+
 function classify(figure) {
   // Manual override wins.
   if (figure.dataset.mode) {
@@ -18,6 +26,7 @@ function classify(figure) {
     // dataset values are 'fit' | 'scroll' | 'modal'; class form is 'fits' | 'scrolls' | 'modal'.
     const classForMode = { fit: 'fits', scroll: 'scrolls', modal: 'modal' }[figure.dataset.mode];
     if (classForMode) figure.classList.add(classForMode);
+    syncTabindex(figure);
     return;
   }
 
@@ -40,6 +49,7 @@ function classify(figure) {
 
   figure.classList.remove('fits', 'scrolls', 'modal');
   figure.classList.add(mode);
+  syncTabindex(figure);
 }
 
 // ── Modal singleton ────────────────────────────────────────────────
@@ -106,6 +116,17 @@ document.body.addEventListener('click', (e) => {
   if (e.target.closest('.mermaid-modal')) return;
   const figure = e.target.closest('.mermaid-diagram.modal');
   if (figure) openModalFor(figure);
+});
+
+// Keyboard activation: Enter or Space opens the modal when a .modal figure is focused.
+document.body.addEventListener('keydown', (e) => {
+  if (e.key !== 'Enter' && e.key !== ' ') return;
+  if (e.target.closest('.mermaid-modal')) return;
+  const figure = e.target.closest?.('.mermaid-diagram.modal');
+  if (figure && document.activeElement === figure) {
+    e.preventDefault();  // stop Space from scrolling the page
+    openModalFor(figure);
+  }
 });
 
 // Render every mermaid <pre> inside a figure and classify each figure.

--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -1,0 +1,27 @@
+// Mermaid adaptive rendering client.
+// Loaded at build time by astro.config.mjs (fs.readFileSync) and inlined
+// as a <script type="module"> in Starlight's head.
+
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+
+// Render every mermaid <pre> inside a figure and (later) classify each figure.
+async function renderAndClassify() {
+  try {
+    await mermaid.run({ querySelector: '.mermaid-diagram pre.mermaid' });
+  } catch (err) {
+    console.error('[mermaid] render failed:', err);
+  }
+  // classifier + modal wiring added in later tasks
+}
+
+// Fire on SPA nav (if view transitions are enabled) AND on initial load.
+// mermaid.run() skips already-processed <pre> elements (data-processed="true"),
+// so running twice is a no-op.
+document.addEventListener('astro:page-load', renderAndClassify);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', renderAndClassify);
+} else {
+  renderAndClassify();
+}

--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -42,6 +42,72 @@ function classify(figure) {
   figure.classList.add(mode);
 }
 
+// ── Modal singleton ────────────────────────────────────────────────
+const MODAL_HTML = `
+<dialog class="mermaid-modal" aria-label="Diagram viewer">
+  <button type="button" class="mermaid-modal__close" aria-label="Close">✕</button>
+  <div class="mermaid-modal__body"></div>
+  <div class="mermaid-modal__zoom">
+    <button type="button" data-zoom="-" aria-label="Zoom out">−</button>
+    <button type="button" data-zoom="0" aria-label="Reset zoom">Reset</button>
+    <button type="button" data-zoom="+" aria-label="Zoom in">+</button>
+  </div>
+</dialog>
+`.trim();
+
+function ensureModal() {
+  let dialog = document.querySelector('.mermaid-modal');
+  if (dialog) return dialog;
+
+  document.body.insertAdjacentHTML('beforeend', MODAL_HTML);
+  dialog = document.querySelector('.mermaid-modal');
+  const body = dialog.querySelector('.mermaid-modal__body');
+
+  // Close button
+  dialog.querySelector('.mermaid-modal__close').addEventListener('click', () => dialog.close());
+
+  // Backdrop click closes (click on the dialog itself, not its children)
+  dialog.addEventListener('click', (e) => {
+    if (e.target === dialog) dialog.close();
+  });
+
+  // On close: clear clone, reset zoom
+  dialog.addEventListener('close', () => {
+    body.innerHTML = '';
+    body.style.setProperty('--zoom', '1');
+  });
+
+  return dialog;
+}
+
+function openModalFor(figure) {
+  const dialog = ensureModal();
+  const body = dialog.querySelector('.mermaid-modal__body');
+  const svg = figure.querySelector('svg');
+  if (!svg) return;
+
+  const clone = svg.cloneNode(true);
+  clone.removeAttribute('id');  // avoid duplicate IDs in DOM
+  body.innerHTML = '';
+  body.appendChild(clone);
+  body.style.setProperty('--zoom', '1');
+
+  // Copy aria-label from the source figure for screen readers
+  const label = figure.getAttribute('aria-label');
+  if (label) dialog.setAttribute('aria-label', label);
+
+  dialog.showModal();
+}
+
+// Event delegation: click on a .modal figure opens the dialog.
+// Listener attached once on document.body — survives SPA nav.
+document.body.addEventListener('click', (e) => {
+  // Don't trigger when clicking inside the already-open dialog.
+  if (e.target.closest('.mermaid-modal')) return;
+  const figure = e.target.closest('.mermaid-diagram.modal');
+  if (figure) openModalFor(figure);
+});
+
 // Render every mermaid <pre> inside a figure and classify each figure.
 async function renderAndClassify() {
   try {

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -101,13 +101,21 @@
   cursor: zoom-in;
   max-height: 420px;
   overflow: hidden;
-  text-align: center;
+  /* Grid centering puts the SVG in the visual center of the card both
+     horizontally and vertically — no inline-block descender space to skew it. */
+  display: grid;
+  place-items: center;
 }
 .mermaid-diagram.modal pre.mermaid {
-  display: block;
+  /* Flex-centre the SVG within the pre so it doesn't sit on the text baseline
+     (which would leave descender space under the SVG and push it visually up
+     inside the grid-centred card). */
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .mermaid-diagram.modal svg {
-  display: inline-block;
+  display: block;
   max-width: 100%;
   max-height: 380px;
   width: auto;
@@ -150,6 +158,10 @@
   border-radius: 12px;
   background: #f8fafc;
   overflow: hidden;
+  /* Centre the dialog in the viewport. Starlight resets margin to 0 on all
+     elements, which clobbers <dialog>'s user-agent `margin: auto` that is
+     responsible for default centring. Re-assert it here. */
+  margin: auto;
 }
 .mermaid-modal::backdrop {
   background: rgba(0, 0, 0, 0.7);

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -4,6 +4,13 @@
   font-weight: 600;
 }
 
+/* Light theme: white text disappears against the pale lavender background.
+   Use a dark indigo that matches the accent family instead. */
+[data-theme='light'] [aria-current="page"] {
+  color: #312e81 !important;
+  background-color: rgba(99, 102, 241, 0.18) !important;
+}
+
 /* ── Mermaid Diagrams — adaptive per-diagram rendering ── */
 
 /* Shared card wrapper (all three strategies) */

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -120,7 +120,7 @@
    reveal the raw source after 3s so users see something rather than a blank card. */
 @keyframes mermaid-fallback-reveal { to { visibility: visible; } }
 .mermaid-diagram pre.mermaid:not([data-processed="true"]) {
-  animation: mermaid-fallback-reveal 0s 3s forwards;
+  animation: mermaid-fallback-reveal 0s 8s forwards;
 }
 
 /* ── Mermaid modal viewer ── */

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -88,9 +88,17 @@
 /* Strategy: .modal — large or tall diagram shown as a capped thumbnail.
    SVG shrinks to fit within max-height while preserving aspect ratio. The
    full-size render happens in the dialog on click. */
+/* Once mermaid renders and the classifier assigns a strategy, the
+   --source-lines min-height reservation has served its CLS-prevention
+   purpose; release it so the card collapses to fit the actual SVG. */
+.mermaid-diagram.fits,
+.mermaid-diagram.scrolls,
+.mermaid-diagram.modal {
+  min-height: 0;
+}
+
 .mermaid-diagram.modal {
   cursor: zoom-in;
-  min-height: 0;           /* override the source-lines CLS reserve on modal thumbnails */
   max-height: 420px;
   overflow: hidden;
   text-align: center;

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -50,7 +50,8 @@
   border: 0;
 }
 
-/* Strategy: .fits — small diagram, centered at natural size */
+/* Strategy: .fits — small diagram, centered at natural size.
+   SVG dimensions set in JS (fixSvgDimensions) as explicit pixels from viewBox. */
 .mermaid-diagram.fits {
   text-align: center;
 }
@@ -60,34 +61,48 @@
 .mermaid-diagram.fits svg {
   display: inline-block;
   max-width: 100%;
-  width: auto;
   height: auto;
 }
 
-/* Strategy: .scrolls — wide diagram, horizontal scroll preserves full size */
+/* Strategy: .scrolls — wide diagram overflows horizontally inside the card.
+   Centering when SVG fits, scroll when it doesn't. Right-edge shadow hints
+   scrollability WITHOUT obscuring content (no mask-image fade). */
 .mermaid-diagram.scrolls {
   overflow-x: auto;
   overflow-y: hidden;
-  mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
-  -webkit-mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+  text-align: center;
+  background-image: linear-gradient(to right, transparent calc(100% - 20px), rgba(0, 0, 0, 0.08) 100%);
+  background-repeat: no-repeat;
+  background-attachment: local;
 }
 .mermaid-diagram.scrolls pre.mermaid {
-  width: max-content;
-  min-width: 100%;
+  display: block;
 }
 .mermaid-diagram.scrolls svg {
-  width: auto;
+  display: inline-block;
+  /* Natural pixel width from fixSvgDimensions; override Starlight's global
+     `max-width: 100%` on SVG so wide diagrams can overflow the card. */
   max-width: none;
-  min-width: 100%;
-  height: auto;
 }
 
-/* Strategy: .modal — huge diagram, thumbnail with "expand" affordance */
+/* Strategy: .modal — large or tall diagram shown as a capped thumbnail.
+   SVG shrinks to fit within max-height while preserving aspect ratio. The
+   full-size render happens in the dialog on click. */
 .mermaid-diagram.modal {
   cursor: zoom-in;
+  min-height: 0;           /* override the source-lines CLS reserve on modal thumbnails */
+  max-height: 420px;
+  overflow: hidden;
+  text-align: center;
+}
+.mermaid-diagram.modal pre.mermaid {
+  display: block;
 }
 .mermaid-diagram.modal svg {
-  width: 100%;
+  display: inline-block;
+  max-width: 100%;
+  max-height: 380px;
+  width: auto;
   height: auto;
 }
 .mermaid-diagram.modal::after {
@@ -100,20 +115,13 @@
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
   border-radius: 4px;
-  opacity: 0;
+  opacity: 0.55;
   transition: opacity 150ms;
   pointer-events: none;
 }
 .mermaid-diagram.modal:hover::after,
 .mermaid-diagram.modal:focus-visible::after {
   opacity: 1;
-}
-
-/* ── Carry-over polish from Task 4 review ── */
-
-/* Touch devices have no hover — always show the expand affordance on modal thumbnails. */
-@media (hover: none) {
-  .mermaid-diagram.modal::after { opacity: 0.9; }
 }
 
 /* If mermaid never sets data-processed (CDN failure, CSP block, render error),
@@ -149,10 +157,12 @@
   box-sizing: border-box;
 }
 .mermaid-modal__body > svg {
-  width: calc(var(--zoom, 1) * 100%);
+  /* At zoom 1, whole diagram fits within viewport (preserving aspect).
+     Zoom > 1 scales up proportionally; user can pan via native scroll. */
+  width: auto;
   height: auto;
-  min-width: 100%;
-  max-width: none;
+  max-width: calc(var(--zoom, 1) * 100%);
+  max-height: calc(var(--zoom, 1) * 100%);
 }
 
 .mermaid-modal__close {

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -108,3 +108,88 @@
 .mermaid-diagram.modal:focus-visible::after {
   opacity: 1;
 }
+
+/* ── Carry-over polish from Task 4 review ── */
+
+/* Touch devices have no hover — always show the expand affordance on modal thumbnails. */
+@media (hover: none) {
+  .mermaid-diagram.modal::after { opacity: 0.9; }
+}
+
+/* If mermaid never sets data-processed (CDN failure, CSP block, render error),
+   reveal the raw source after 3s so users see something rather than a blank card. */
+@keyframes mermaid-fallback-reveal { to { visibility: visible; } }
+.mermaid-diagram pre.mermaid:not([data-processed="true"]) {
+  animation: mermaid-fallback-reveal 0s 3s forwards;
+}
+
+/* ── Mermaid modal viewer ── */
+.mermaid-modal {
+  width: 95vw;
+  height: 90vh;
+  max-width: none;
+  max-height: none;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: #f8fafc;
+  overflow: hidden;
+}
+.mermaid-modal::backdrop {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.mermaid-modal__body {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  box-sizing: border-box;
+}
+.mermaid-modal__body > svg {
+  width: calc(var(--zoom, 1) * 100%);
+  height: auto;
+  min-width: 100%;
+  max-width: none;
+}
+
+.mermaid-modal__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  z-index: 1;
+}
+.mermaid-modal__close:hover { background: rgba(0, 0, 0, 0.85); }
+
+.mermaid-modal__zoom {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 0.25rem;
+  border-radius: 8px;
+}
+.mermaid-modal__zoom > button {
+  min-width: 2.25rem;
+  padding: 0.35rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: #fff;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.mermaid-modal__zoom > button:hover { background: rgba(255, 255, 255, 0.15); }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -4,22 +4,107 @@
   font-weight: 600;
 }
 
-/* ── Mermaid Diagrams ── */
-/* SVGs are rendered with hardcoded light-mode colors by rehype-mermaid.
-   In dark mode (the default for this site), wrap them in a light card so
-   connectors, node backgrounds, and text all remain readable. */
-svg[id^="mermaid-"] {
+/* ── Mermaid Diagrams — adaptive per-diagram rendering ── */
+
+/* Shared card wrapper (all three strategies) */
+.mermaid-diagram {
   display: block;
-  max-width: 100%;
-  margin: 1.5rem auto;
-  border-radius: 8px;
+  margin: 1.5rem 0;
   padding: 1.25rem 1.5rem;
-  background-color: #f8fafc;
   border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: #f8fafc;
+  min-height: calc(var(--source-lines, 4) * 1.75em);
+  box-sizing: border-box;
+  position: relative;
 }
 
-/* In light mode: transparent background (diagram colours already work) */
-[data-theme='light'] svg[id^="mermaid-"] {
-  background-color: transparent;
-  border-color: #e2e8f0;
+[data-theme='light'] .mermaid-diagram {
+  background: transparent;
+}
+
+/* Neutralize default <pre> styling inside the figure so the SVG paints cleanly. */
+.mermaid-diagram pre.mermaid {
+  margin: 0;
+  padding: 0;
+  background: none;
+  border: none;
+  font-family: inherit;
+  color: inherit;
+  overflow: visible;
+  white-space: normal;
+}
+
+/* Hide the raw mermaid text before mermaid renders the SVG (kills FOUT/flash). */
+.mermaid-diagram pre.mermaid:not([data-processed="true"]) {
+  visibility: hidden;
+}
+
+.mermaid-diagram figcaption.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Strategy: .fits — small diagram, centered at natural size */
+.mermaid-diagram.fits {
+  text-align: center;
+}
+.mermaid-diagram.fits pre.mermaid {
+  display: inline-block;
+}
+.mermaid-diagram.fits svg {
+  display: inline-block;
+  max-width: 100%;
+  width: auto;
+  height: auto;
+}
+
+/* Strategy: .scrolls — wide diagram, horizontal scroll preserves full size */
+.mermaid-diagram.scrolls {
+  overflow-x: auto;
+  overflow-y: hidden;
+  mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+}
+.mermaid-diagram.scrolls pre.mermaid {
+  width: max-content;
+  min-width: 100%;
+}
+.mermaid-diagram.scrolls svg {
+  width: auto;
+  max-width: none;
+  min-width: 100%;
+  height: auto;
+}
+
+/* Strategy: .modal — huge diagram, thumbnail with "expand" affordance */
+.mermaid-diagram.modal {
+  cursor: zoom-in;
+}
+.mermaid-diagram.modal svg {
+  width: 100%;
+  height: auto;
+}
+.mermaid-diagram.modal::after {
+  content: "⤢ expand";
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 150ms;
+  pointer-events: none;
+}
+.mermaid-diagram.modal:hover::after,
+.mermaid-diagram.modal:focus-visible::after {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary

Per-diagram adaptive rendering for mermaid:

- **Build-time rehype plugin** emits `<figure class="mermaid-diagram">` wrappers with `role="img"`, `aria-label`, and an inline `--source-lines` CSS var (reserves height → zero CLS).
- **Runtime classifier** measures each rendered SVG's viewBox vs. container width and assigns exactly one of `.fits` / `.scrolls` / `.modal` — different CSS strategy per class.
- **Native `<dialog>` zoom-pan modal** for diagrams classified as `.modal`. No library dependency; uses native scroll for pan and a `--zoom` CSS var (50% → 300%, step 25%).
- **Magic-comment override** (`%% mode:fit|scroll|modal %%`) parsed at build time — zero uses in content on day one; auto handles all 82 diagrams.
- `mermaid.initialize({ startOnLoad: false })` + explicit `mermaid.run()` on `astro:page-load` + `DOMContentLoaded`. Safe across SPA navigation and initial load.
- `fixSvgDimensions()` post-render helper: strips mermaid's `width="100%"` + inline max-width and sets explicit viewBox-derived pixel attrs so our CSS controls final size predictably.
- Mermaid theme set to `default` with pinned themeVariables so text/nodes are legible on the light card in both site-dark and site-light.

## Why

Prior attempts used a single layout for all diagrams and broke on at least one diagram per attempt. The insight: no single layout fits — classify per diagram, apply the right strategy for each.

## No Vercel risk

- No Playwright, no build-time browser.
- Mermaid still renders client-side via CDN exactly as before.
- Pure AST string transforms at build time.

## Known tech debt (follow-up)

- Modal clone keeps the source SVG's root id on purpose (mermaid's scoped stylesheet is keyed by it). While the dialog is open, the id is duplicated in the DOM — a minor a11y concern. Fix via id-rewriting in the clone is deferred.

## Test plan

- [x] `npm run build` completes locally with no errors
- [x] EN small-diagram page: `.fits` classification verified in DevTools
- [x] EN wide-LR page (Secret Leak Chain): `.scrolls` with horizontal scroll and readable text
- [x] EN tall-TD pages (Decision Flowchart, Complete Security Stack): `.modal` thumbnails readable, "⤢ expand" pill visible
- [x] Modal: opens on click AND Enter key; Esc closes; zoom +/−/Reset work
- [x] VI parity: same classifications on VI counterpart page
- [x] Mobile viewport (DevTools 390px): `.scrolls` diagrams re-classify to `.modal`
- [x] SPA nav between diagram pages: all diagrams render on both; no duplicates
- [ ] Vercel preview deployment green