### PR TITLE
fix: prevent mermaid client crash before body exists

### DIFF
--- a/src/scripts/mermaid-client.js
+++ b/src/scripts/mermaid-client.js
@@ -169,7 +169,7 @@ function openModalFor(figure) {
 
 // Event delegation: click on a .modal figure opens the dialog.
 // Listener attached once on document.body — survives SPA nav.
-document.body.addEventListener('click', (e) => {
+document.addEventListener('click', (e) => {
   // Don't trigger when clicking inside the already-open dialog.
   if (e.target.closest('.mermaid-modal')) return;
   const figure = e.target.closest('.mermaid-diagram.modal');
@@ -177,7 +177,7 @@ document.body.addEventListener('click', (e) => {
 });
 
 // Keyboard activation: Enter or Space opens the modal when a .modal figure is focused.
-document.body.addEventListener('keydown', (e) => {
+document.addEventListener('keydown', (e) => {
   if (e.key !== 'Enter' && e.key !== ' ') return;
   if (e.target.closest('.mermaid-modal')) return;
   const figure = e.target.closest?.('.mermaid-diagram.modal');


### PR DESCRIPTION
## Summary
Fixes a regression where Mermaid diagrams could fail to render (showing raw Mermaid source) because the inlined client script could throw before document.body exists.

## Problem
src/scripts/mermaid-client.js is inlined into <head> and previously attached listeners via document.body.addEventListener(...). During initial HTML parsing, document.body can be null, causing an early runtime exception and preventing mermaid.run(...) from executing.

## Solution
Use document.addEventListener(...) for event delegation instead of document.body, so listener registration does not depend on <body> being available yet.

## Files changed
src/scripts/mermaid-client.js
Test plan

 npm run dev

 Visit pages with Mermaid diagrams, e.g.:
/en/claude-code/phase-01-foundation/02-interfaces-modes/
/en/claude-code/phase-02-security/02-permission-system/

 Confirm diagrams render as SVG (not raw ```mermaid source)

 Open browser console and confirm no early document.body null errors

 npm run build (optional but recommended)

## Testing
### Before 
<img width="1280" height="383" alt="image" src="https://github.com/user-attachments/assets/902f80af-d28c-443e-9afb-fc3182f23835" />

### After
<img width="1080" height="367" alt="Screenshot 2026-04-17 at 11 15 29" src="https://github.com/user-attachments/assets/1967a28a-91d6-42a4-8d36-305e90c8be38" />


## Notes
This change is intentionally minimal and scoped to the Mermaid client runtime.
If you still see Made-with: Cursor appended to commit messages, that’s coming from your local tooling/hooks—not this code change.