### PR TITLE
Fix mobile docs menu layering behind custom header

### DIFF
--- a/src/styles/starlight-overrides.css
+++ b/src/styles/starlight-overrides.css
@@ -234,6 +234,12 @@ header {
   z-index: 50;
 }
 
+@media (max-width: 49.999rem) {
+  header {
+    z-index: var(--sl-z-index-navbar);
+  }
+}
+
 [data-theme="light"] header {
   background-color: rgba(248, 250, 252, 0.85);
 }


### PR DESCRIPTION
 ## What does this PR do?

  Fixes the mobile docs/blog navigation layering so the sidebar menu is no longer hidden behind the custom fixed header on small screens. The change is minimal and only affects
  mobile header z-index behavior, preserving the existing desktop layout.

  ## Related issue

  Mobile UI issue where the docs/blog menu appears hidden while reading content pages.

  ## Checklist
  - [x] No spelling/grammar errors
  - [x] Tested locally with npm run dev